### PR TITLE
attach: accept 0 or 1 argument to kernel json

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A popup will appear and list all the available kernels to connect to, sorted by 
 
 # References
 Only the following commands are provided, without any default keymaps.
-- `JupyterAttach`: select a running kernel to attach
+- `JupyterAttach`: 1st argument is path to kernel's json. If no path is provided, a popup will appear to select a running kernel to attach.
 - `JupyterDetach`: detach buffer from kernel
 - `JupyterInspect`: inspect object under cursor. This command send the current line and cursor location to `jupyter_client`, it is up to the kernel to decide which object to inspect.
 

--- a/lua/jupyter_kernel/init.lua
+++ b/lua/jupyter_kernel/init.lua
@@ -1,16 +1,24 @@
 local M = {}
 
-function M.attach()
-	local _ = vim.fn.JupyterKernels() -- not sure why but 1st called always return nil
-	local kernels = vim.fn.JupyterKernels()
-	vim.ui.select(kernels, { prompt = "Select a kernel" }, function(kernel)
-		if kernel == nil then
-			return
-		end
-		vim.fn.JupyterAttach(kernel)
-		vim.b.jupyter_attached = true
-		vim.notify("Jupyter kernel attached")
-	end)
+local function _attach(kernel)
+	vim.fn.JupyterAttach(kernel)
+	vim.b.jupyter_attached = true
+	vim.notify("Attach to " .. kernel)
+end
+
+function M.attach(opts)
+	local kernel = opts.args -- User supplied full path
+	if kernel ~= "" then -- User didn't supply full path
+		_attach(kernel)
+	else
+		vim.fn.JupyterKernels() -- not sure why but 1st called always return nil
+		local kernels = vim.fn.JupyterKernels(kernel)
+		kernel = vim.ui.select(kernels, { prompt = "Select a kernel" }, function(kernel)
+			if kernel ~= nil then
+				_attach(kernel)
+			end
+		end)
+	end
 end
 
 function M.inspect()

--- a/plugin/jupyter_kernel.lua
+++ b/plugin/jupyter_kernel.lua
@@ -3,7 +3,7 @@ require("cmp").register_source("jupyter", require("jupyter_kernel.cmp").new())
 vim.api.nvim_create_user_command(
 	"JupyterAttach",
 	require("jupyter_kernel").attach,
-	{ desc = "Attach to a running jupyter kernel" }
+	{ nargs = "?", desc = "Attach to a running jupyter kernel" }
 )
 
 vim.api.nvim_create_user_command("JupyterDetach", "call JupyterDetach()", { desc = "Detach jupyter kernel" })


### PR DESCRIPTION
`JupyterAttach` now accept 1 argument is the path to the json kernel.
@WhiteBlackGoose is this similar to what you have in mind?
![Screenshot 2023-02-26 at 14 58 50](https://user-images.githubusercontent.com/12573521/221418429-77c0d0b9-67e4-435c-bbee-b38ce2a71aa5.png)
